### PR TITLE
MCC-269990: Rerun new automation failed scenarios in Jenkins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
@@ -79,10 +79,10 @@ public class CucumberTestResult extends MetaTabulatedResult {
 	private transient int skipCount;
 	private transient float duration;
 
+	private String nameAppendix = "";
 
 	public CucumberTestResult() {
 	}
-
 
 	/**
 	 * Add a FeatureResult to this TestResult
@@ -222,7 +222,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	// @Override - this is an interface method
 	public String getDisplayName() {
-		return "Cucumber Test Results";
+		return "Cucumber Test Results " + (nameAppendix == null ? "" : nameAppendix);
 	}
 	
 
@@ -328,6 +328,14 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	@Override
 	public String getDescription() {
-		return "Cucumber Test Results";
+		return "Cucumber Test Results " + (nameAppendix == null ? "" : nameAppendix);
+	}
+
+	public String getNameAppendix() {
+		return nameAppendix;
+	}
+
+	public void setNameAppendix(String nameAppendix) {
+		this.nameAppendix = nameAppendix;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
@@ -84,6 +84,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 	public CucumberTestResult() {
 	}
 
+
 	/**
 	 * Add a FeatureResult to this TestResult
 	 * 

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResult.java
@@ -223,7 +223,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	// @Override - this is an interface method
 	public String getDisplayName() {
-		return "Cucumber Test Results " + (nameAppendix == null ? "" : nameAppendix);
+		return "Cucumber Test Results " + nameAppendix;
 	}
 	
 
@@ -329,7 +329,7 @@ public class CucumberTestResult extends MetaTabulatedResult {
 
 	@Override
 	public String getDescription() {
-		return "Cucumber Test Results " + (nameAppendix == null ? "" : nameAppendix);
+		return "Cucumber Test Results " + nameAppendix;
 	}
 
 	public String getNameAppendix() {

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultAction.java
@@ -66,7 +66,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
 
    private static final Logger LOGGER = Logger.getLogger(CucumberTestResultAction.class.getName());
 
-   private static final XStream XSTREAM = new XStream2();
+   protected static final XStream XSTREAM = new XStream2();
 
    private transient WeakReference<CucumberTestResult> result;
    
@@ -111,7 +111,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
        this.result = new WeakReference<CucumberTestResult>(result);
    }
 	
-   private XmlFile getDataFile() {
+   protected XmlFile getDataFile() {
       return new XmlFile(XSTREAM,new File(run.getRootDir(), "cucumberResult.xml"));
   }
 
@@ -202,7 +202,7 @@ public class CucumberTestResultAction extends AbstractTestResultAction<CucumberT
 	 *           the result to merge with the current results.
 	 * @param listener
 	 */
-	synchronized void mergeResult(CucumberTestResult other, TaskListener listener) {
+	protected synchronized void mergeResult(CucumberTestResult other, TaskListener listener) {
 		CucumberTestResult cr = getResult();
 		for (FeatureResult fr : other.getFeatures()) {
 			// We need to add =the new results to the existing ones to keep the names stable

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
@@ -61,7 +61,7 @@ import java.util.regex.Pattern;
 
 /**
  * Generates HTML report from Cucumber JSON files.
- * 
+ *
  * @author James Nord
  * @author Kohsuke Kawaguchi (original JUnit code)
  */
@@ -183,39 +183,41 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 		return true;
 	}
 
-	private void parseRerunResults(Run<?, ?> build, FilePath workspace, Launcher launcher,
-																 TaskListener listener, String testResultsPath,
-																 CucumberJSONParser parser) throws IOException, InterruptedException {
+  private void parseRerunResults(Run<?, ?> build, FilePath workspace, Launcher launcher,
+                                 TaskListener listener, String testResultsPath,
+                                 CucumberJSONParser parser) throws IOException, InterruptedException {
 
-		parseRerunWithNumberIfExists(1, build, workspace, launcher, listener, testResultsPath, parser);
-		parseRerunWithNumberIfExists(2, build, workspace, launcher, listener, testResultsPath, parser);
-	}
+    parseRerunWithNumberIfExists(1, build, workspace, launcher, listener, testResultsPath, parser);
+    parseRerunWithNumberIfExists(2, build, workspace, launcher, listener, testResultsPath, parser);
+  }
 
-	private void parseRerunWithNumberIfExists(int number, Run<?, ?> build, FilePath workspace, Launcher launcher,
-																						TaskListener listener, String testResultsPath,
-																						CucumberJSONParser parser) throws IOException, InterruptedException {
-		String rerunFilePath = filterRerunFilePath(workspace, testResultsPath, number);
-		if (!Strings.isNullOrEmpty(rerunFilePath)) {
-			CucumberTestResult rerunResult = parser.parseResult(rerunFilePath, build, workspace, launcher, listener);
-			rerunResult.setNameAppendix("Rerun " + number);
-			try {
-				Class rerunActionClass = Class.forName(getRerunActionClassName(number));
-				reportResultForAction(rerunActionClass, build, listener, rerunResult);
-			} catch (Exception e) {
-				LOGGER.log(Level.FINE, "Unable to process rerun with number " + number, e);
-			}
-		}
-	}
+  private void parseRerunWithNumberIfExists(int number, Run<?, ?> build, FilePath workspace,
+                                            Launcher launcher, TaskListener listener,
+                                            String testResultsPath,
+                                            CucumberJSONParser parser) throws IOException, InterruptedException {
+    String rerunFilePath = filterRerunFilePath(workspace, testResultsPath, number);
+    if (!Strings.isNullOrEmpty(rerunFilePath)) {
+      CucumberTestResult rerunResult = parser.parseResult(rerunFilePath, build, workspace, launcher, listener);
+      rerunResult.setNameAppendix("Rerun " + number);
+      try {
+        Class rerunActionClass = Class.forName(getRerunActionClassName(number));
+        reportResultForAction(rerunActionClass, build, listener, rerunResult);
+      } catch (Exception e) {
+        LOGGER.log(Level.FINE, "Unable to process rerun with number " + number, e);
+      }
+    }
+  }
 
-	private String getRerunActionClassName(int number) {
-		return getClass().getPackage().getName() +
+  private String getRerunActionClassName(int number) {
+    return getClass().getPackage().getName() +
         ".rerun.CucumberRerun" + number + "TestResultAction";
-	}
+  }
 
-	private CucumberTestResultAction reportResultForAction(Class actionClass, Run<?, ?> build, TaskListener listener,
-																												 CucumberTestResult result) throws Exception {
-		CucumberTestResultAction action = (CucumberTestResultAction) build.getAction(actionClass);
-		if (action == null) {
+  private CucumberTestResultAction reportResultForAction(Class actionClass, Run<?, ?> build,
+                                                         TaskListener listener,
+                                                         CucumberTestResult result) throws Exception {
+    CucumberTestResultAction action = (CucumberTestResultAction) build.getAction(actionClass);
+    if (action == null) {
       Constructor actionClassConstructor = actionClass.getConstructor(Run.class, CucumberTestResult.class, TaskListener.class);
       action = (CucumberTestResultAction) actionClassConstructor.newInstance(build, result, listener);
       if (!ignoreDiffTracking) {
@@ -235,18 +237,18 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
     return action;
 	}
 
-	private String filterRerunFilePath(FilePath workspace, String testResultsPath, int number) throws IOException, InterruptedException {
-		FilePath[] paths = workspace.list(testResultsPath);
-		for (FilePath filePath : paths) {
-			String remote = filePath.getRemote();
-			Pattern p = Pattern.compile("rerun" + number + ".cucumber.json");
-			Matcher m = p.matcher(remote);
-			if (m.find()) {
-				return "**/" + remote.substring(m.start());
-			}
-		}
-		return "";
-	}
+  private String filterRerunFilePath(FilePath workspace, String testResultsPath, int number) throws IOException, InterruptedException {
+    FilePath[] paths = workspace.list(testResultsPath);
+    for (FilePath filePath : paths) {
+      String remote = filePath.getRemote();
+      Pattern p = Pattern.compile("rerun" + number + ".cucumber.json");
+      Matcher m = p.matcher(remote);
+      if (m.find()) {
+        return "**/" + remote.substring(m.start());
+      }
+    }
+    return "";
+  }
 
 
 	/**
@@ -266,7 +268,7 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 	public Collection<Action> getProjectActions(AbstractProject<?, ?> project) {
 		return Collections.<Action> singleton(new TestResultProjectAction((Job)project));
 	}
-	
+
 
 	public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
 		return new TestResultAggregator(build, launcher, listener);
@@ -286,7 +288,7 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 
 
 	/**
-	 * {@link Callable} that gets the temporary directory from the node. 
+	 * {@link Callable} that gets the temporary directory from the node.
 	 */
 	private final static class TmpDirCallable extends MasterToSlaveCallable<String, InterruptedException> {
 
@@ -328,7 +330,7 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 			if (project != null) {
 				return FilePath.validateFileMask(project.getSomeWorkspace(), value);
 			}
-			return FormValidation.ok(); 
+			return FormValidation.ok();
 		}
 
 

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java
@@ -56,6 +56,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Generates HTML report from Cucumber JSON files.
@@ -192,7 +194,7 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
 	private void parseRerunWithNumberIfExists(int number, Run<?, ?> build, FilePath workspace, Launcher launcher,
 																						TaskListener listener, String testResultsPath,
 																						CucumberJSONParser parser) throws IOException, InterruptedException {
-		String rerunFilePath = filterFileThatContains(workspace, testResultsPath, "rerun" + number);
+		String rerunFilePath = filterRerunFilePath(workspace, testResultsPath, number);
 		if (!Strings.isNullOrEmpty(rerunFilePath)) {
 			CucumberTestResult rerunResult = parser.parseResult(rerunFilePath, build, workspace, launcher, listener);
 			rerunResult.setNameAppendix("Rerun " + number);
@@ -233,13 +235,14 @@ public class CucumberTestResultArchiver extends Recorder implements MatrixAggreg
     return action;
 	}
 
-	private String filterFileThatContains(FilePath workspace, String testResultsPath, String filePathPart) throws IOException, InterruptedException {
+	private String filterRerunFilePath(FilePath workspace, String testResultsPath, int number) throws IOException, InterruptedException {
 		FilePath[] paths = workspace.list(testResultsPath);
-		for(FilePath filePath : paths){
+		for (FilePath filePath : paths) {
 			String remote = filePath.getRemote();
-			int index = remote.indexOf(filePathPart);
-			if(index > 0){
-				return "**/"+ remote.substring(index);
+			Pattern p = Pattern.compile("rerun" + number + ".cucumber.json");
+			Matcher m = p.matcher(remote);
+			if (m.find()) {
+				return "**/" + remote.substring(m.start());
 			}
 		}
 		return "";

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
@@ -64,6 +64,7 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 
 	public static final boolean IGNORE_TIMESTAMP_CHECK = Boolean.getBoolean(TestResultParser.class.getName()
 	                                                                        + ".ignoreTimestampCheck");
+	public static final String RERUN_CUCUMBER_JSON_REGEX = ".*rerun\\d+.cucumber.json";
 
 
 	/**
@@ -162,11 +163,11 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 		}
 
 		private boolean shouldSkipFile(boolean isRerunAction, FilePath path) {
-			return !isRerunAction && path.getRemote().contains("rerun");
+			return !isRerunAction && path.getRemote().matches(RERUN_CUCUMBER_JSON_REGEX);
 		}
 
 		private boolean isRerunAction() {
-			return testResultLocations.contains("rerun");
+			return testResultLocations.matches(RERUN_CUCUMBER_JSON_REGEX);
 		}
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/DefaultTestResultParserImpl.java
@@ -140,6 +140,7 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 			// since dir is local, paths all point to the local files
 			List<File> files = new ArrayList<File>(paths.length);
 			for (FilePath path : paths) {
+				if(shouldSkipFile(isRerunAction(), path)) continue;
 				File report = new File(path.getRemote());
 				if (ignoreTimestampCheck || localBuildTime - 3000 /* error margin */< report.lastModified()) {
 					// this file is created during this build
@@ -158,6 +159,14 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
 			}
 
 			return parserImpl.parse(files, listener);
+		}
+
+		private boolean shouldSkipFile(boolean isRerunAction, FilePath path) {
+			return !isRerunAction && path.getRemote().contains("rerun");
+		}
+
+		private boolean isRerunAction() {
+			return testResultLocations.contains("rerun");
 		}
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+
+
+public class CucumberRerun1TestResultAction extends CucumberRerunTestResultAction {
+
+  @Override
+  protected int getNumber() {
+    return 1;
+  }
+
+  public CucumberRerun1TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun1TestResultAction.java
@@ -4,16 +4,20 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
 
-
+/**
+ * Used to generate rerun results. Accessed with reflection - do not move or rename without
+ * modifying {@link org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultArchiver#getRerunActionClassName(int)}
+ */
 public class CucumberRerun1TestResultAction extends CucumberRerunTestResultAction {
+
+
+  public CucumberRerun1TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
 
   @Override
   protected int getNumber() {
     return 1;
-  }
-
-  public CucumberRerun1TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
-    super(owner, result, listener);
   }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+
+
+public class CucumberRerun2TestResultAction extends CucumberRerunTestResultAction {
+
+  @Override
+  protected int getNumber() {
+    return 2;
+  }
+
+  public CucumberRerun2TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerun2TestResultAction.java
@@ -4,15 +4,18 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
 
-
+/**
+ * Used to generate rerun results. Accessed with reflection - do not move or rename without
+ * modifying {@link org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultArchiver#getRerunActionClassName(int)}
+ */
 public class CucumberRerun2TestResultAction extends CucumberRerunTestResultAction {
+
+  public CucumberRerun2TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
 
   @Override
   protected int getNumber() {
     return 2;
-  }
-
-  public CucumberRerun2TestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
-    super(owner, result, listener);
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerunTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/rerun/CucumberRerunTestResultAction.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.cucumber.jsontestsupport.rerun;
+
+import hudson.XmlFile;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResult;
+import org.jenkinsci.plugins.cucumber.jsontestsupport.CucumberTestResultAction;
+
+import java.io.File;
+
+
+public abstract class CucumberRerunTestResultAction extends CucumberTestResultAction {
+
+  protected abstract int getNumber();
+
+  public CucumberRerunTestResultAction(Run<?, ?> owner, CucumberTestResult result, TaskListener listener) {
+    super(owner, result, listener);
+  }
+
+  @Override
+  protected XmlFile getDataFile() {
+    return new XmlFile(XSTREAM, new File(run.getRootDir(), "cucumberRerunResult" + getNumber() + ".xml"));
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "Cucumber Rerun " + getNumber() + " Result";
+  }
+
+  @Override
+  public String getUrlName() {
+    return "cucumberRerun" + getNumber();
+  }
+
+}


### PR DESCRIPTION
#### What is this PR for?
This PR is to modify cucumber-testresult-plugin to publish results of rerunning initially failed cucumber scenarios.
New version of plugin reads rerun cucumber results from path _**/rerunN/cucumber.json_ where N={1,2} and displays them separately in Jenkins build.

#### Who should review this PR?
@mdsol/black-jaguars 
@mdsol/silver-hippogriffs 
@mdsol/blue-oyster 
@mdsol/golden-eagles

#### What are the relevant JIRA tickets?
https://jira.mdsol.com/browse/MCC-269990

Sample screens:
<img width="525" alt="screen shot 2016-12-15 at 12 20 35 pm" src="https://cloud.githubusercontent.com/assets/23030120/21223824/22d16aee-c2c1-11e6-82b5-a64d2a5f6e1f.png">
<img width="485" alt="screen shot 2016-12-15 at 12 21 17 pm" src="https://cloud.githubusercontent.com/assets/23030120/21223825/22d39008-c2c1-11e6-8677-f1afa09e5912.png">
